### PR TITLE
Fix: Properly handle filenames with spaces

### DIFF
--- a/SOURCES/7zcat
+++ b/SOURCES/7zcat
@@ -434,7 +434,7 @@ fi
 
 unset opt optn optm optv optt optk
 
-optv="$*" ; optt=""
+optv="$*" ; optt=()
 
 while [[ -n "$1" ]] ; do
   if [[ "$1" =~ \  && -n "$optn" ]] ; then
@@ -524,7 +524,7 @@ while [[ -n "$1" ]] ; do
     fi
   fi
 
-  optt="$optt $1" ; shift
+  optt+=("$1") ; shift
 done
 
 [[ -n "$optn" ]] && declare "$optn=true"
@@ -532,6 +532,6 @@ done
 unset opt optn optm optk
 
 # shellcheck disable=SC2015,SC2086
-[[ -n "$KEEP_OPTS" ]] && main $optv || main ${optt:1}
+[[ -n "$KEEP_OPTS" ]] && main $optv || main "${optt[@]}"
 
 ################################################################################


### PR DESCRIPTION
This update resolves an issue in the argument parsing logic where filenames containing spaces were improperly handled. Previously, filenames with spaces were concatenated into a single string (optt), causing them to be split incorrectly when passed to subsequent functions.

- Replaced string concatenation of filenames (`optt`) with an array to preserve arguments containing spaces.
- Updated argument passing to use `"${optt[@]}"` for proper handling of filenames with spaces.
- Ensured compatibility with existing CLI option parsing logic.

This change resolves an issue where filenames with spaces were split incorrectly, improving robustness and usability when processing diverse input scenarios.
